### PR TITLE
Add a sequence number to event processor events

### DIFF
--- a/src/effects/adsr/adsr_node.rs
+++ b/src/effects/adsr/adsr_node.rs
@@ -42,38 +42,36 @@ impl Adsr {
 
     /// Trigger a note on at a particular time
     pub fn note_on_at_time(&mut self, time: Timestamp) {
-        let _ = self.event_transmitter.send(AdsrEvent {
-            time,
-            event_type: AdsrEventType::NoteOn,
-        });
+        let _ = self
+            .event_transmitter
+            .send(AdsrEvent::new(time, AdsrEventType::NoteOn));
     }
 
     /// Trigger a note off at a particular time
     pub fn note_off_at_time(&mut self, time: Timestamp) {
-        let _ = self.event_transmitter.send(AdsrEvent {
-            time,
-            event_type: AdsrEventType::NoteOff,
-        });
+        let _ = self
+            .event_transmitter
+            .send(AdsrEvent::new(time, AdsrEventType::NoteOff));
     }
 
     /// Set the attack time
     ///
     /// This is the time from the note on until the gain reaches unity
     pub fn set_attack_time(&mut self, attack_time: Duration) {
-        let _ = self.event_transmitter.send(AdsrEvent {
-            time: Timestamp::zero(),
-            event_type: AdsrEventType::SetAttack(attack_time),
-        });
+        let _ = self.event_transmitter.send(AdsrEvent::new(
+            Timestamp::zero(),
+            AdsrEventType::SetAttack(attack_time),
+        ));
     }
 
     /// Set the decay time
     ///
     /// This is the time after the end of the attack time to reach the steady-state sustain level
     pub fn set_decay_time(&mut self, decay_time: Duration) {
-        let _ = self.event_transmitter.send(AdsrEvent {
-            time: Timestamp::zero(),
-            event_type: AdsrEventType::SetDecay(decay_time),
-        });
+        let _ = self.event_transmitter.send(AdsrEvent::new(
+            Timestamp::zero(),
+            AdsrEventType::SetDecay(decay_time),
+        ));
     }
 
     /// Set the sustain level
@@ -81,20 +79,20 @@ impl Adsr {
     /// This is the level that will be sustained after the attack and decay phase
     /// until a note off
     pub fn set_sustain_level(&mut self, sustain_level: Level) {
-        let _ = self.event_transmitter.send(AdsrEvent {
-            time: Timestamp::zero(),
-            event_type: AdsrEventType::SetSustain(sustain_level),
-        });
+        let _ = self.event_transmitter.send(AdsrEvent::new(
+            Timestamp::zero(),
+            AdsrEventType::SetSustain(sustain_level),
+        ));
     }
 
     /// Set the release time
     ///
     /// This is the time after a note off until gain of 0 is reached
     pub fn set_release_time(&mut self, release_time: Duration) {
-        let _ = self.event_transmitter.send(AdsrEvent {
-            time: Timestamp::zero(),
-            event_type: AdsrEventType::SetRelease(release_time),
-        });
+        let _ = self.event_transmitter.send(AdsrEvent::new(
+            Timestamp::zero(),
+            AdsrEventType::SetRelease(release_time),
+        ));
     }
 
     /// Convenience method to set the attack, decay, sustain, and release in one go

--- a/src/effects/adsr/adsr_processor.rs
+++ b/src/effects/adsr/adsr_processor.rs
@@ -41,15 +41,17 @@ impl AdsrProcessor {
     }
 
     fn process_event(&mut self, event: AdsrEvent) {
-        match event.event_type {
+        match event.get_event_type() {
             AdsrEventType::NoteOn => self.envelope.open(),
             AdsrEventType::NoteOff => self.envelope.close(),
-            AdsrEventType::SetAttack(attack_time) => self.envelope.set_attack_time(attack_time),
-            AdsrEventType::SetDecay(decay_time) => self.envelope.set_decay_time(decay_time),
+            AdsrEventType::SetAttack(attack_time) => self.envelope.set_attack_time(*attack_time),
+            AdsrEventType::SetDecay(decay_time) => self.envelope.set_decay_time(*decay_time),
             AdsrEventType::SetSustain(sustain_level) => {
-                self.envelope.set_sustain_level(sustain_level)
+                self.envelope.set_sustain_level(*sustain_level)
             }
-            AdsrEventType::SetRelease(release_time) => self.envelope.set_release_time(release_time),
+            AdsrEventType::SetRelease(release_time) => {
+                self.envelope.set_release_time(*release_time)
+            }
         }
     }
 

--- a/src/effects/sampler/sampler_event.rs
+++ b/src/effects/sampler/sampler_event.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use crate::{effects::utility::EventProcessorEvent, Timestamp};
 
 #[derive(Debug, PartialEq, PartialOrd)]
@@ -12,14 +14,26 @@ pub enum SampleEventType {
     CancelAll,
 }
 
+fn next_sequence_number() -> usize {
+    static SEQUENCE_NUMBER: AtomicUsize = AtomicUsize::new(0);
+    SEQUENCE_NUMBER.fetch_add(1, Ordering::Relaxed)
+}
+
+#[derive(Debug)]
 pub struct SamplerEvent {
-    pub time: Timestamp,
-    pub event_type: SampleEventType,
+    sequence_number: usize,
+    time: Timestamp,
+    event_type: SampleEventType,
 }
 
 impl SamplerEvent {
+    pub fn get_event_type(&self) -> &SampleEventType {
+        &self.event_type
+    }
+
     pub fn start(start_at_time: Timestamp, position_in_sample: Timestamp) -> Self {
         Self {
+            sequence_number: next_sequence_number(),
             time: start_at_time,
             event_type: SampleEventType::Start(position_in_sample),
         }
@@ -27,6 +41,7 @@ impl SamplerEvent {
 
     pub fn start_now() -> Self {
         Self {
+            sequence_number: next_sequence_number(),
             time: Timestamp::zero(),
             event_type: SampleEventType::StartImmediate,
         }
@@ -34,6 +49,7 @@ impl SamplerEvent {
 
     pub fn stop(stop_at_time: Timestamp) -> Self {
         Self {
+            sequence_number: next_sequence_number(),
             time: stop_at_time,
             event_type: SampleEventType::Stop,
         }
@@ -41,6 +57,7 @@ impl SamplerEvent {
 
     pub fn stop_now() -> Self {
         Self {
+            sequence_number: next_sequence_number(),
             time: Timestamp::zero(),
             event_type: SampleEventType::Stop,
         }
@@ -52,6 +69,7 @@ impl SamplerEvent {
         loop_end: Timestamp,
     ) -> Self {
         Self {
+            sequence_number: next_sequence_number(),
             time: enable_at_time,
             event_type: SampleEventType::EnableLoop(loop_start, loop_end),
         }
@@ -59,6 +77,7 @@ impl SamplerEvent {
 
     pub fn cancel_loop_at_time(cancel_time: Timestamp) -> Self {
         Self {
+            sequence_number: next_sequence_number(),
             time: cancel_time,
             event_type: SampleEventType::CancelLoop,
         }
@@ -66,6 +85,7 @@ impl SamplerEvent {
 
     pub fn enable_loop(loop_start: Timestamp, loop_end: Timestamp) -> Self {
         Self {
+            sequence_number: next_sequence_number(),
             time: Timestamp::zero(),
             event_type: SampleEventType::EnableLoop(loop_start, loop_end),
         }
@@ -73,6 +93,7 @@ impl SamplerEvent {
 
     pub fn cancel_loop() -> Self {
         Self {
+            sequence_number: next_sequence_number(),
             time: Timestamp::zero(),
             event_type: SampleEventType::CancelLoop,
         }
@@ -80,6 +101,7 @@ impl SamplerEvent {
 
     pub fn cancel_all() -> Self {
         Self {
+            sequence_number: next_sequence_number(),
             time: Timestamp::zero(),
             event_type: SampleEventType::CancelAll,
         }
@@ -93,5 +115,9 @@ impl EventProcessorEvent for SamplerEvent {
 
     fn should_clear_queue(&self) -> bool {
         self.event_type == SampleEventType::CancelAll
+    }
+
+    fn sequence_number(&self) -> usize {
+        self.sequence_number
     }
 }

--- a/src/effects/sampler/sampler_node.rs
+++ b/src/effects/sampler/sampler_node.rs
@@ -125,6 +125,7 @@ impl Sampler {
     }
 
     fn send_event(&mut self, event: SamplerEvent) {
+        println!("Sending {event:?}");
         debug_assert!(!self.event_transmitter.is_full());
         let _ = self.event_transmitter.send(event);
     }

--- a/src/effects/sampler/sampler_processor.rs
+++ b/src/effects/sampler/sampler_processor.rs
@@ -1,7 +1,10 @@
 use std::time::Duration;
 
 use crate::{
-    effects::{utility::EventProcessor, Channel},
+    effects::{
+        utility::{EventProcessor, EventProcessorEvent},
+        Channel,
+    },
     graph::DspProcessor,
     AudioBuffer, MutableBorrowedAudioBuffer, OwnedAudioBuffer, ProcessContext, Timestamp,
 };
@@ -205,15 +208,17 @@ impl SamplerDspProcess {
     }
 
     fn process_event(&mut self, event: &SamplerEvent, current_time: &Timestamp) {
-        match event.event_type {
+        println!("Event: {event:?}");
+
+        match event.get_event_type() {
             SampleEventType::StartImmediate => self.start(Timestamp::zero(), Timestamp::zero()),
             SampleEventType::Start(position_in_sample) => {
-                let delay = *current_time - event.time;
-                self.start(position_in_sample, delay);
+                let delay = *current_time - event.get_time();
+                self.start(*position_in_sample, delay);
             }
             SampleEventType::Stop => self.stop(),
             SampleEventType::EnableLoop(loop_start, loop_end) => {
-                self.set_loop_points(loop_start, loop_end)
+                self.set_loop_points(*loop_start, *loop_end)
             }
             SampleEventType::CancelLoop => self.clear_loop_points(),
             SampleEventType::CancelAll => self.cancel_all(),

--- a/src/effects/utility/event_processor.rs
+++ b/src/effects/utility/event_processor.rs
@@ -3,6 +3,7 @@ use crate::{effects::Channel, Timestamp};
 pub trait EventProcessorEvent {
     fn get_time(&self) -> Timestamp;
     fn should_clear_queue(&self) -> bool;
+    fn sequence_number(&self) -> usize;
 }
 
 pub struct EventProcessor<Event>
@@ -43,11 +44,11 @@ where
         }
 
         if sort_required {
-            self.pending_events.sort_by(|a, b| {
-                let a_time = a.get_time();
-                let b_time = b.get_time();
-                a_time.partial_cmp(&b_time).unwrap()
-            });
+            self.pending_events
+                .sort_by(|a, b| match a.get_time().cmp(&b.get_time()) {
+                    std::cmp::Ordering::Equal => a.sequence_number().cmp(&b.sequence_number()),
+                    comparison => comparison,
+                });
         }
     }
 

--- a/src/utility/level.rs
+++ b/src/utility/level.rs
@@ -1,7 +1,7 @@
 pub const MINUS_INFINITY_DECIBELS: f64 = -128.0;
 
 /// A level that can be used to convert from linear to decibel representation
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
 pub struct Level {
     gain: f64,
 }


### PR DESCRIPTION
This allows events at the same time to preserve the order they were sent